### PR TITLE
feat: 전문가 정보 등록,조회,수정 연동 개발

### DIFF
--- a/daily-nuts-client/src/assets/css/ExpertInfo.css
+++ b/daily-nuts-client/src/assets/css/ExpertInfo.css
@@ -85,6 +85,14 @@
   margin-top: 10px;
 }
 
+.empty-info {
+    gap: 20px;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
 .preview-image {
   width: 80px;
   height: 80px;

--- a/daily-nuts-client/src/components/ExpertInfo.jsx
+++ b/daily-nuts-client/src/components/ExpertInfo.jsx
@@ -1,190 +1,75 @@
-import { useEffect, useState } from 'react';
-import { saveExpertInfo, getExpertInfo } from '../service/ExpertInfoService';
+import { useState, useEffect } from 'react';
+import { getExpertInfo, saveExpertInfo, updateExpertInfo } from '../service/ExpertInfoService';
+import ExpertInfoView from './ExpertInfoView';
+import ExpertInfoForm from './ExpertInfoForm';
 import '../assets/css/ExpertInfo.css';
-
-const info = {
-  description : ``,
-  certifications : [
-  ]
-}
+import { HttpStatusCode } from 'axios';
 
 const ExpertInfo = () => {
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState({
-    description: info.description,
-    files: info.certifications,         // 실제 파일
-    previewUrls: []    // 미리보기 URL
-  });
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [info, setInfo] = useState(null);
 
-const handleFileUpload = (e) => {
-  const uploadedFiles = Array.from(e.target.files);
-  const newPreviewUrls = uploadedFiles.map(file => URL.createObjectURL(file));
-
-  setFormData(prev => ({
-    ...prev,
-    files: [...prev.files, ...uploadedFiles],
-    previewUrls: [...prev.previewUrls, ...newPreviewUrls]
-  }));
-};
-
-  const handleTextChange = (e) => {
-    setFormData({
-      ...formData,
-      description: e.target.value
+  useEffect(() => {
+    getExpertInfo().then((res) => {
+      console.log(res);
+      setInfo(res?.data || null);
     });
-  };
-
-  const removeFile = (index) => {
-    const updatedFiles = formData.files.filter((_, i) => i !== index);
-    setFormData({
-      ...formData,
-      files: updatedFiles
-    });
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    console.log(formData.description)
-    if(!formData.description) {
-      alert("증명내용을 입력해주세요.");
-      return;
-    }
-    console.log(formData.files);
-    if(!formData.files.length) {
-      alert("증명 파일을 추가해주세요.");
-      return;
-    }
-    console.log('전문가 등록 정보:', formData);
-
-    saveExpertInfo(formData.description, formData.files)
-      .then((res) => {
-        console.log(res);
-        setIsEditing(false)
-      }
-    );
-  };
+  }, []);
 
   const handleEdit = () => {
     setIsEditing(true);
+    setIsRegistering(false);
+  };
+
+  const handleRegister = () => {
+    setIsRegistering(true);
+    setIsEditing(false);
   };
 
   const handleCancel = () => {
     setIsEditing(false);
-    setFormData({
-      profileDescription: info.description,
-      files: []
-    });
+    setIsRegistering(false);
   };
 
-    // 컴포넌트 언마운트 시 메모리 해제
-  useEffect(() => {
-    return () => {
-      getExpertInfo().then((res) => {
-        console.log(res);
-      })
-
-      if(formData.previewUrls) formData.previewUrls.forEach((url) => URL.revokeObjectURL(url));
-    };
-  }, [formData.previewUrls]);
+  const handleSave = (formData) => {
+    const action = isRegistering ? saveExpertInfo : updateExpertInfo;
+    action(formData.description, formData.files).then((res) => {
+      if((isRegistering && res.status === HttpStatusCode.Created) || 
+      (!isRegistering && res.status === HttpStatusCode.Ok)) {
+        console.log('저장 완료:', res);
+        setIsEditing(false);
+        setIsRegistering(false);
+        setInfo(res.data);
+      } else {
+        alert(res.data.message);
+      }
+    });
+  };
 
   return (
     <div className="profile-card">
       <h2 className="page-title">전문가 등록 정보</h2>
-      
-      {!isEditing ? (
-        // 조회 화면
-        <div className="info-view">
-          <div className="info-section">
-            <h3 className="section-title">프로필 설명</h3>
-            <div className="profile-description">
-              {info.description}
-            </div>
-          </div>
 
-          <div className="info-section">
-            <h3 className="section-title">첨부자료</h3>
-            <div className="file-list">
-              {info.certifications.map((cert, index) => (
-                <div key={index} className="file-item-view">
-                  <div className="file-info">
-                    <span className="file-icon">📄</span>
-                    <span className="file-name">{cert.name}</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <button onClick={handleEdit} className="edit-button">
-            수정하기
-          </button>
-        </div>
-      ) : (
-        // 수정 화면
-        <form onSubmit={handleSubmit} className="registration-form">
-          <div className="form-section">
-            <h3 className="section-title">프로필 설명</h3>
-            <textarea
-              className="profile-textarea"
-              value={formData.profileDescription}
-              onChange={handleTextChange}
-              placeholder={info.description}
-              rows="8"
-            />
-          </div>
-
-          <div className="form-section">
-            <h3 className="section-title">첨부자료</h3>
-            
-            <div className="file-upload-section">
-              <label htmlFor="file-upload" className="file-upload-label">
-                <div className="upload-icon">📁</div>
-                파일 선택
-              </label>
-              <input
-                id="file-upload"
-                type="file"
-                multiple
-                accept=".jpg,.jpeg,.png,.pdf,.doc,.docx"
-                onChange={handleFileUpload}
-                className="file-input"
-              />
-            </div>
-
-            <div className="preview-container">
-              {formData.previewUrls.map((url, index) => (
-                <img key={index} src={url} alt={`preview-${index}`} className="preview-image" />
-              ))}
-            </div>
-
-            <div className="file-list">
-              {formData.files.map((file, index) => (
-                <div key={index} className="file-item">
-                  <div className="file-info">
-                    <span className="file-icon">📄</span>
-                    <span className="file-name">{file.name}</span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => removeFile(index)}
-                    className="remove-file-btn"
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="button-group">
-            <button type="submit" className="submit-button">
-              저장하기
-            </button>
-            <button type="button" onClick={handleCancel} className="cancel-button">
-              취소
+      {!isEditing && !isRegistering && (
+        info && info.description ? (
+          <ExpertInfoView info={info} onEdit={handleEdit} />
+        ) : (
+          <div className="empty-info">
+            <p>전문가 등록 정보가 존재하지 않습니다.</p>
+            <button className="register-button" onClick={handleRegister}>
+              등록하기
             </button>
           </div>
-        </form>
+        )
+      )}
+
+      {(isEditing || isRegistering) && (
+        <ExpertInfoForm
+          initialData={isEditing ? info : { description: '', files: [] }}
+          onCancel={handleCancel}
+          onSave={handleSave}
+        />
       )}
     </div>
   );

--- a/daily-nuts-client/src/components/ExpertInfoForm.jsx
+++ b/daily-nuts-client/src/components/ExpertInfoForm.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+
+const ExpertInfoForm = ({ initialData, onCancel, onSave }) => {
+  const [formData, setFormData] = useState({
+    description: initialData.description || '',
+    files: initialData.files || [],
+    previewUrls: []
+  });
+
+  const handleTextChange = (e) => {
+    setFormData({ ...formData, description: e.target.value });
+  };
+
+  const handleFileUpload = (e) => {
+    const uploadedFiles = Array.from(e.target.files);
+    const newPreviewUrls = uploadedFiles.map((file) => URL.createObjectURL(file));
+    setFormData((prev) => ({
+      ...prev,
+      files: [...prev.files, ...uploadedFiles],
+      previewUrls: [...prev.previewUrls, ...newPreviewUrls]
+    }));
+  };
+
+  const removeFile = (index) => {
+    const updatedFiles = formData.files.filter((_, i) => i !== index);
+    setFormData({ ...formData, files: updatedFiles });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!formData.description) {
+      alert('증명내용을 입력해주세요.');
+      return;
+    }
+    if (!formData.files.length) {
+      alert('증명 파일을 추가해주세요.');
+      return;
+    }
+    onSave(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="registration-form">
+      <div className="form-section">
+        <h3 className="section-title">프로필 설명</h3>
+        <textarea
+          className="profile-textarea"
+          value={formData.description}
+          onChange={handleTextChange}
+          placeholder="프로필 설명을 입력하세요"
+          rows="8"
+        />
+      </div>
+
+      <div className="form-section">
+        <h3 className="section-title">첨부자료</h3>
+        <div className="file-upload-section">
+          <label htmlFor="file-upload" className="file-upload-label">
+            <div className="upload-icon">📁</div>
+            파일 선택
+          </label>
+          <input
+            id="file-upload"
+            type="file"
+            multiple
+            accept=".jpg,.jpeg,.png,.pdf,.doc,.docx"
+            onChange={handleFileUpload}
+            className="file-input"
+          />
+        </div>
+
+        <div className="preview-container">
+          {formData.previewUrls.map((url, index) => (
+            <img key={index} src={url} alt={`preview-${index}`} className="preview-image" />
+          ))}
+        </div>
+
+        <div className="file-list">
+          {formData.files.map((file, index) => (
+            <div key={index} className="file-item">
+              <div className="file-info">
+                <span className="file-icon">📄</span>
+                <span className="file-name">{file.name}</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeFile(index)}
+                className="remove-file-btn"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="button-group">
+        <button type="submit" className="submit-button">
+          저장하기
+        </button>
+        <button type="button" onClick={onCancel} className="cancel-button">
+          취소
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ExpertInfoForm;

--- a/daily-nuts-client/src/components/ExpertInfoView.jsx
+++ b/daily-nuts-client/src/components/ExpertInfoView.jsx
@@ -1,0 +1,31 @@
+const ExpertInfoView = ({ info, onEdit }) => {
+  return (
+    <div className="info-view">
+      <div className="info-section">
+        <h3 className="section-title">프로필 설명</h3>
+        <div className="profile-description">{info.description}</div>
+      </div>
+
+      <div className="info-section">
+        <h3 className="section-title">첨부자료</h3>
+        <div className="file-list">
+          {!info.filesinfo ? 
+          info.files.map((cert, index) => (
+            <div key={index} className="file-item-view">
+              <div className="file-info">
+                <span className="file-icon">📄</span>
+                <span className="file-name">{cert.name}</span>
+              </div>
+            </div>
+          )) : ''}
+        </div>
+      </div>
+
+      <button onClick={onEdit} className="edit-button">
+        수정하기
+      </button>
+    </div>
+  );
+};
+
+export default ExpertInfoView;

--- a/daily-nuts-client/src/service/ExpertInfoService.jsx
+++ b/daily-nuts-client/src/service/ExpertInfoService.jsx
@@ -21,6 +21,7 @@ const saveExpertInfo = async (description, files) => {
         return res;
     }).catch((error) => {
         console.log(error);
+        return error;
     })
 }
 
@@ -53,4 +54,4 @@ const updateExpertInfo = async (description, files) => {
     })
 }
 
-export {saveExpertInfo, getExpertInfo};
+export {saveExpertInfo, getExpertInfo, updateExpertInfo};

--- a/daily-nuts-server/src/main/java/com/dailynuts/member/controller/ExpertController.java
+++ b/daily-nuts-server/src/main/java/com/dailynuts/member/controller/ExpertController.java
@@ -43,6 +43,6 @@ public class ExpertController {
             @RequestPart(name = "files", required = false) List<MultipartFile> files,
             @AuthenticationPrincipal JwtMember memberInfo) {
         ExpertInfoResponseDto response = expertInfoService.updateExpertInfo(expertInfoRequest, files, memberInfo);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/daily-nuts-server/src/main/java/com/dailynuts/member/dto/ExpertInfoResponseDto.java
+++ b/daily-nuts-server/src/main/java/com/dailynuts/member/dto/ExpertInfoResponseDto.java
@@ -9,15 +9,15 @@ import java.util.List;
 @Getter
 public class ExpertInfoResponseDto {
     public String description;
-    public List<ImageInfo> images;
+    public List<ImageInfo> files;
 
     public ExpertInfoResponseDto(String description) {
         this.description = description;
-        this.images = new ArrayList<>();
+        this.files = new ArrayList<>();
     }
 
     public void addImage(String name, String url) {
-        images.add(new ImageInfo(name, url));
+        files.add(new ImageInfo(name, url));
     }
 
     @Getter

--- a/daily-nuts-server/src/main/java/com/dailynuts/member/entity/ExpertInfo.java
+++ b/daily-nuts-server/src/main/java/com/dailynuts/member/entity/ExpertInfo.java
@@ -44,14 +44,16 @@ public class ExpertInfo {
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime updatedAt;
 
-    public ExpertInfo(String description) {
+    public ExpertInfo(Member member, String description) {
         this.description = description;
+        this.member = member;
         this.images = new HashSet<>();
         this.isApproved = false;
     }
 
     public void addImage(ExpertCertificationImage image) {
         image.setExpertInfo(this);
+        images.add(image);
     }
 
     public void updateDescription(String description) {

--- a/daily-nuts-server/src/main/java/com/dailynuts/member/service/ExpertInfoServiceImpl.java
+++ b/daily-nuts-server/src/main/java/com/dailynuts/member/service/ExpertInfoServiceImpl.java
@@ -7,9 +7,11 @@ import com.dailynuts.member.dto.ExpertInfoResponseDto;
 import com.dailynuts.member.entity.ExpertCertificationImage;
 import com.dailynuts.member.entity.ExpertInfo;
 import com.dailynuts.member.entity.Image;
+import com.dailynuts.member.entity.Member;
 import com.dailynuts.member.entity.type.ImageType;
 import com.dailynuts.member.repository.ExpertInfoRepository;
 import com.dailynuts.member.repository.ImageRepository;
+import com.dailynuts.member.repository.MemberRepository;
 import com.dailynuts.member.service.mapper.ExpertInfoMapper;
 import com.dailynuts.security.jwt.JwtMember;
 import jakarta.transaction.Transactional;
@@ -31,6 +33,7 @@ public class ExpertInfoServiceImpl implements ExpertInfoService {
     private final ImageRepository imageRepository;
     private final FileService fileService;
     private final ExpertInfoMapper mapper;
+    private final MemberRepository memberRepository;
 
     @Override
     public ExpertInfoResponseDto createExpertInfo(ExpertInfoRequestDto request, List<MultipartFile> files, JwtMember memberInfo) {
@@ -39,7 +42,10 @@ public class ExpertInfoServiceImpl implements ExpertInfoService {
             throw new CustomException(CustomErrorCode.EXPERT_ALREADY_EXIST);
         }
 
-        ExpertInfo expertInfo = new ExpertInfo(request.getDescription());
+        Member member = memberRepository.findByLoginId(memberInfo.getLoginId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+
+        ExpertInfo expertInfo = new ExpertInfo(member, request.getDescription());
         List<Image> images = getImagesAndSetToExpertInfo(files, expertInfo, memberInfo.getLoginId());
         expertInfoRepository.save(expertInfo);
 
@@ -72,8 +78,8 @@ public class ExpertInfoServiceImpl implements ExpertInfoService {
     private List<Image> getImagesAndSetToExpertInfo(List<MultipartFile> files, ExpertInfo expertInfo, String loginId) {
         List<Image> images = new ArrayList<>();
         files.forEach(file -> {
-            String url = fileService.createFile(file);
-            String name = loginId + "_" + file.getOriginalFilename();
+            String url = fileService.createFile(loginId, file);
+            String name = file.getOriginalFilename();
             Image image = new Image(name, url, ImageType.CERTIFICATION);
             ExpertCertificationImage expertCertificationImage = new ExpertCertificationImage();
             expertCertificationImage.setImage(image);

--- a/daily-nuts-server/src/main/java/com/dailynuts/member/service/FileService.java
+++ b/daily-nuts-server/src/main/java/com/dailynuts/member/service/FileService.java
@@ -6,6 +6,6 @@ import java.io.IOException;
 import java.util.List;
 
 public interface FileService {
-    void createFiles(List<MultipartFile> files);
-    String createFile(MultipartFile file);
+    void createFiles(String loginId, List<MultipartFile> files);
+    String createFile(String loginId, MultipartFile file);
 }

--- a/daily-nuts-server/src/main/java/com/dailynuts/member/service/FileServiceImpl.java
+++ b/daily-nuts-server/src/main/java/com/dailynuts/member/service/FileServiceImpl.java
@@ -9,32 +9,40 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Slf4j
 @Service
 public class FileServiceImpl implements FileService {
 
+    private static final String DATE_FORMAT = "yyyyMMdd";
+    private static final String FILE_FULL_PATH_FORMAT = "%s%s_%s_%s";
+
     @Value("${image.path}")
     private String imagePath;
 
     @Override
-    public void createFiles(List<MultipartFile> files) {
+    public void createFiles(String loginId, List<MultipartFile> files) {
         log.info("UploadFiles: {}", files.size());
         for(MultipartFile file : files) {
-            createFile(file);
+            createFile(loginId, file);
         }
     }
 
     @Override
-    public String createFile(MultipartFile file) {
+    public String createFile(String loginId, MultipartFile file) {
         log.info("UploadFile: {}", file.getOriginalFilename());
-        String fullPath = imagePath + file.getOriginalFilename();
+
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT));
+        String fullPath = String.format(FILE_FULL_PATH_FORMAT, imagePath, loginId, date, file.getOriginalFilename());
         log.debug("Full path: {}", fullPath);
 
         try {
             file.transferTo(new File(fullPath));
         } catch (IOException e) {
+            e.printStackTrace();
             throw new CustomException(CustomErrorCode.FILE_SAVE_FAIL);
         }
 


### PR DESCRIPTION
## 백엔드 개발
- 전문가 정보 저장 시 이미지 같이 저장되도록 로직 수정
- 이미지 파일 이름 포맷 추가 (로그인아이디_날짜_기존파일명)

## 프론트엔드 개발
- 조회화면, 등록폼 컴포넌트 분리
- 업데이트 기능 추가 연동
- 전문가 정보 없을 시 등록하기 버튼 생성